### PR TITLE
Implement basic local auth flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import SpreadSelection from './components/SpreadSelection';
 import QuestionForm from './components/QuestionForm';
 import PaymentFlow from './components/PaymentFlow';
 import ReadingResults from './components/ReadingResults';
+import AuthPage from './components/AuthPage';
+import { useAuth } from './context/AuthContext';
 
 export type SpreadType = 'single' | 'three-card' | 'celtic-cross';
 
@@ -24,10 +26,15 @@ export interface Reading {
 }
 
 function App() {
+  const { user, logout } = useAuth();
   const [currentStep, setCurrentStep] = useState<'landing' | 'spread' | 'question' | 'payment' | 'results'>('landing');
   const [selectedSpread, setSelectedSpread] = useState<SpreadType>('single');
   const [question, setQuestion] = useState('');
   const [reading, setReading] = useState<Reading | null>(null);
+
+  if (!user) {
+    return <AuthPage />;
+  }
 
   const handleSpreadSelection = (spread: SpreadType) => {
     setSelectedSpread(spread);
@@ -195,7 +202,13 @@ Esta lectura completa sugiere una situación compleja pero navegable. Confía en
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 relative">
+      <button
+        onClick={logout}
+        className="absolute top-4 right-4 text-purple-200 hover:text-white z-10"
+      >
+        Cerrar Sesión
+      </button>
       {/* Mystical background elements */}
       <div className="fixed inset-0 overflow-hidden pointer-events-none">
         <div className="absolute top-10 left-10 text-purple-400/20 animate-pulse">

--- a/src/components/AuthPage.tsx
+++ b/src/components/AuthPage.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+const AuthPage: React.FC = () => {
+  const { login, register } = useAuth();
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      if (mode === 'login') {
+        await login(username, password);
+      } else {
+        if (password !== confirm) {
+          setError('Las contraseñas no coinciden');
+          return;
+        }
+        await register(username, password);
+      }
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="max-w-md w-full bg-white/5 backdrop-blur-sm p-8 rounded-2xl border border-purple-400/20">
+        <h1 className="text-3xl font-serif text-transparent bg-gradient-to-r from-purple-400 to-amber-400 bg-clip-text text-center mb-6">
+          {mode === 'login' ? 'Iniciar Sesión' : 'Crear Cuenta'}
+        </h1>
+        {error && <p className="text-red-400 mb-4">{error}</p>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Usuario"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            required
+            className="w-full p-3 rounded-lg bg-white/10 border border-purple-400/30 text-purple-100 focus:outline-none"
+          />
+          <input
+            type="password"
+            placeholder="Contraseña"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+            className="w-full p-3 rounded-lg bg-white/10 border border-purple-400/30 text-purple-100 focus:outline-none"
+          />
+          {mode === 'register' && (
+            <input
+              type="password"
+              placeholder="Confirmar Contraseña"
+              value={confirm}
+              onChange={e => setConfirm(e.target.value)}
+              required
+              className="w-full p-3 rounded-lg bg-white/10 border border-purple-400/30 text-purple-100 focus:outline-none"
+            />
+          )}
+          <button
+            type="submit"
+            className="w-full bg-gradient-to-r from-purple-600 to-amber-600 text-white py-3 rounded-lg"
+          >
+            {mode === 'login' ? 'Entrar' : 'Registrarse'}
+          </button>
+        </form>
+        <button
+          onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
+          className="mt-4 text-sm text-purple-300 hover:text-purple-100 w-full text-center"
+        >
+          {mode === 'login' ? '¿No tienes cuenta? Regístrate' : '¿Ya tienes cuenta? Inicia sesión'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AuthPage;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import * as auth from '../services/auth';
+
+interface AuthContextProps {
+  user: string | null;
+  login: (u: string, p: string) => Promise<void>;
+  register: (u: string, p: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextProps>({
+  user: null,
+  login: async () => {},
+  register: async () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<string | null>(null);
+
+  useEffect(() => {
+    setUser(auth.getCurrentUser());
+  }, []);
+
+  const login = async (username: string, password: string) => {
+    await auth.login(username, password);
+    setUser(auth.getCurrentUser());
+  };
+
+  const registerUser = async (username: string, password: string) => {
+    await auth.register(username, password);
+    setUser(auth.getCurrentUser());
+  };
+
+  const logout = () => {
+    auth.logout();
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, register: registerUser, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { AuthProvider } from './context/AuthContext';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>
 );

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,49 @@
+export interface User {
+  username: string;
+  passwordHash: string;
+}
+
+const USER_KEY = 'tm_users';
+const SESSION_KEY = 'tm_session';
+
+function getUsers(): Record<string, string> {
+  const data = localStorage.getItem(USER_KEY);
+  return data ? JSON.parse(data) : {};
+}
+
+async function hashPassword(password: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(password);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function register(username: string, password: string): Promise<void> {
+  const users = getUsers();
+  if (users[username]) {
+    throw new Error('El usuario ya existe');
+  }
+  const hash = await hashPassword(password);
+  users[username] = hash;
+  localStorage.setItem(USER_KEY, JSON.stringify(users));
+  localStorage.setItem(SESSION_KEY, username);
+}
+
+export async function login(username: string, password: string): Promise<void> {
+  const users = getUsers();
+  const hash = await hashPassword(password);
+  if (users[username] !== hash) {
+    throw new Error('Credenciales inválidas');
+  }
+  localStorage.setItem(SESSION_KEY, username);
+}
+
+export function logout(): void {
+  localStorage.removeItem(SESSION_KEY);
+}
+
+export function getCurrentUser(): string | null {
+  return localStorage.getItem(SESSION_KEY);
+}


### PR DESCRIPTION
## Summary
- implement localStorage-based auth service
- add auth context provider
- create login/registration page
- require authentication in the app
- show a logout button and wrap App with provider

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ebe41403483328717b6635068cca7