### PR TITLE
Add user panel with PDF export

### DIFF
--- a/src/components/UserPanel.tsx
+++ b/src/components/UserPanel.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { ArrowLeft, Eye, Download } from 'lucide-react';
+import { Reading } from '../App';
+import { useAuth } from '../context/AuthContext';
+import { getReadings, exportReadingToPdf } from '../services/readings';
+
+interface UserPanelProps {
+  onSelect: (reading: Reading) => void;
+  onBack: () => void;
+}
+
+const UserPanel: React.FC<UserPanelProps> = ({ onSelect, onBack }) => {
+  const { user } = useAuth();
+  const readings = user ? getReadings(user) : [];
+
+  return (
+    <div className="min-h-screen py-12 px-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="text-center mb-12">
+          <button
+            onClick={onBack}
+            className="inline-flex items-center text-purple-300 hover:text-purple-200 transition-colors mb-6"
+          >
+            <ArrowLeft size={20} className="mr-2" />
+            Volver
+          </button>
+          <h1 className="text-4xl font-serif text-transparent bg-gradient-to-r from-purple-400 to-amber-400 bg-clip-text font-bold mb-4">
+            Mis Lecturas
+          </h1>
+        </div>
+        {readings.length === 0 ? (
+          <p className="text-purple-200 text-center">Aún no tienes lecturas guardadas.</p>
+        ) : (
+          <div className="space-y-6">
+            {readings.map((r) => (
+              <div key={r.id} className="bg-white/5 backdrop-blur-sm rounded-2xl p-6 border border-purple-400/20 flex flex-col sm:flex-row sm:items-center justify-between">
+                <div className="mb-4 sm:mb-0">
+                  <p className="text-purple-200 font-serif mb-1">{r.question}</p>
+                  <p className="text-purple-300 text-sm">{new Date(r.timestamp).toLocaleString()}</p>
+                </div>
+                <div className="flex space-x-3">
+                  <button
+                    onClick={() => onSelect(r)}
+                    className="flex items-center bg-white/10 hover:bg-white/20 text-purple-200 py-2 px-4 rounded-lg"
+                  >
+                    <Eye size={18} className="mr-2" /> Ver
+                  </button>
+                  <button
+                    onClick={() => exportReadingToPdf(r)}
+                    className="flex items-center bg-white/10 hover:bg-white/20 text-purple-200 py-2 px-4 rounded-lg"
+                  >
+                    <Download size={18} className="mr-2" /> PDF
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UserPanel;

--- a/src/services/readings.ts
+++ b/src/services/readings.ts
@@ -1,0 +1,32 @@
+export interface SavedReadings {
+  [user: string]: import('../App').Reading[];
+}
+
+const READINGS_KEY = 'tm_readings';
+
+export function getReadings(user: string): import('../App').Reading[] {
+  const data = localStorage.getItem(READINGS_KEY);
+  if (!data) return [];
+  const all: SavedReadings = JSON.parse(data);
+  return all[user] || [];
+}
+
+export function saveReading(user: string, reading: import('../App').Reading): void {
+  const data = localStorage.getItem(READINGS_KEY);
+  const all: SavedReadings = data ? JSON.parse(data) : {};
+  if (!all[user]) all[user] = [];
+  all[user].push(reading);
+  localStorage.setItem(READINGS_KEY, JSON.stringify(all));
+}
+
+export function exportReadingToPdf(reading: import('../App').Reading): void {
+  const win = window.open('', '_blank');
+  if (!win) return;
+  const style = `body{font-family:serif;background:#1e1b4b;color:#e0d8ff;padding:2rem;}h1{color:#fcd34d;}h2{color:#ddd6fe;}p{margin-bottom:1rem;} .card{border:1px solid #a78bfa;padding:0.5rem;margin-bottom:0.5rem;border-radius:0.5rem;} .position{color:#fcd34d;font-weight:bold;}`;
+  const cardsHtml = reading.cards.map(c => `<div class="card"><h3>${c.name}</h3><p class="position">${c.position}${c.reversed ? ' (Invertida)' : ''}</p><p>${c.meaning}</p></div>`).join('');
+  const html = `<html><head><title>Lectura</title><style>${style}</style></head><body><h1>Tarot Místico</h1><h2>Pregunta</h2><p>${reading.question}</p><h2>Cartas</h2>${cardsHtml}<h2>Interpretación</h2>${reading.interpretation.split('\n').map(p=>`<p>${p}</p>`).join('')}</body></html>`;
+  win.document.write(html);
+  win.document.close();
+  win.focus();
+  win.print();
+}


### PR DESCRIPTION
## Summary
- add services to save and export readings
- create a simple user panel to view past readings
- store completed readings and display them in a new screen
- add button to access user panel and download PDF

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fc56b1e508332a6fbea9d6385d320