### PR TITLE
Enhance auth UI

### DIFF
--- a/src/components/AuthPage.tsx
+++ b/src/components/AuthPage.tsx
@@ -5,8 +5,10 @@ const AuthPage: React.FC = () => {
   const { login, register } = useAuth();
   const [mode, setMode] = useState<'login' | 'register'>('login');
   const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
+  const [remember, setRemember] = useState(true);
   const [error, setError] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -14,13 +16,13 @@ const AuthPage: React.FC = () => {
     setError('');
     try {
       if (mode === 'login') {
-        await login(username, password);
+        await login(username, password, remember);
       } else {
         if (password !== confirm) {
           setError('Las contraseñas no coinciden');
           return;
         }
-        await register(username, password);
+        await register(username, password, email);
       }
     } catch (err: any) {
       setError(err.message);
@@ -28,9 +30,9 @@ const AuthPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
+    <div className="min-h-screen py-12 px-4 flex items-center justify-center">
       <div className="max-w-md w-full bg-white/5 backdrop-blur-sm p-8 rounded-2xl border border-purple-400/20">
-        <h1 className="text-3xl font-serif text-transparent bg-gradient-to-r from-purple-400 to-amber-400 bg-clip-text text-center mb-6">
+        <h1 className="text-4xl font-serif text-transparent bg-gradient-to-r from-purple-400 to-amber-400 bg-clip-text text-center mb-6">
           {mode === 'login' ? 'Iniciar Sesión' : 'Crear Cuenta'}
         </h1>
         {error && <p className="text-red-400 mb-4">{error}</p>}
@@ -43,6 +45,16 @@ const AuthPage: React.FC = () => {
             required
             className="w-full p-3 rounded-lg bg-white/10 border border-purple-400/30 text-purple-100 focus:outline-none"
           />
+          {mode === 'register' && (
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+              className="w-full p-3 rounded-lg bg-white/10 border border-purple-400/30 text-purple-100 focus:outline-none"
+            />
+          )}
           <input
             type="password"
             placeholder="Contraseña"
@@ -60,6 +72,17 @@ const AuthPage: React.FC = () => {
               required
               className="w-full p-3 rounded-lg bg-white/10 border border-purple-400/30 text-purple-100 focus:outline-none"
             />
+          )}
+          {mode === 'login' && (
+            <label className="flex items-center text-purple-200">
+              <input
+                type="checkbox"
+                className="mr-2"
+                checked={remember}
+                onChange={e => setRemember(e.target.checked)}
+              />
+              Recordar contraseña
+            </label>
           )}
           <button
             type="submit"

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -3,8 +3,8 @@ import * as auth from '../services/auth';
 
 interface AuthContextProps {
   user: string | null;
-  login: (u: string, p: string) => Promise<void>;
-  register: (u: string, p: string) => Promise<void>;
+  login: (u: string, p: string, remember?: boolean) => Promise<void>;
+  register: (u: string, p: string, e?: string) => Promise<void>;
   logout: () => void;
 }
 
@@ -22,13 +22,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(auth.getCurrentUser());
   }, []);
 
-  const login = async (username: string, password: string) => {
-    await auth.login(username, password);
+  const login = async (username: string, password: string, remember = true) => {
+    await auth.login(username, password, remember);
     setUser(auth.getCurrentUser());
   };
 
-  const registerUser = async (username: string, password: string) => {
-    await auth.register(username, password);
+  const registerUser = async (username: string, password: string, email?: string) => {
+    await auth.register(username, password, email);
     setUser(auth.getCurrentUser());
   };
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,12 +1,13 @@
 export interface User {
   username: string;
   passwordHash: string;
+  email?: string;
 }
 
 const USER_KEY = 'tm_users';
 const SESSION_KEY = 'tm_session';
 
-function getUsers(): Record<string, string> {
+function getUsers(): Record<string, User> {
   const data = localStorage.getItem(USER_KEY);
   return data ? JSON.parse(data) : {};
 }
@@ -20,30 +21,36 @@ async function hashPassword(password: string): Promise<string> {
     .join('');
 }
 
-export async function register(username: string, password: string): Promise<void> {
+export async function register(username: string, password: string, email?: string): Promise<void> {
   const users = getUsers();
   if (users[username]) {
     throw new Error('El usuario ya existe');
   }
   const hash = await hashPassword(password);
-  users[username] = hash;
+  users[username] = { passwordHash: hash, email };
   localStorage.setItem(USER_KEY, JSON.stringify(users));
   localStorage.setItem(SESSION_KEY, username);
 }
 
-export async function login(username: string, password: string): Promise<void> {
+export async function login(username: string, password: string, remember = true): Promise<void> {
   const users = getUsers();
+  const user = users[username];
   const hash = await hashPassword(password);
-  if (users[username] !== hash) {
+  if (!user || user.passwordHash !== hash) {
     throw new Error('Credenciales inválidas');
   }
-  localStorage.setItem(SESSION_KEY, username);
+  if (remember) {
+    localStorage.setItem(SESSION_KEY, username);
+  } else {
+    sessionStorage.setItem(SESSION_KEY, username);
+  }
 }
 
 export function logout(): void {
   localStorage.removeItem(SESSION_KEY);
+  sessionStorage.removeItem(SESSION_KEY);
 }
 
 export function getCurrentUser(): string | null {
-  return localStorage.getItem(SESSION_KEY);
+  return localStorage.getItem(SESSION_KEY) || sessionStorage.getItem(SESSION_KEY);
 }


### PR DESCRIPTION
## Summary
- update login/register styling to match other pages
- add email field on registration
- add remember password checkbox on login
- support remember session logic in auth service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fcfb11f408332a42d40321846d3b8