### PR TITLE
Add palmistry service

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Star, Moon, Sun, Sparkles } from 'lucide-react';
 import { generateTarotReading } from './services/openai';
+import PalmistryPage from './components/PalmistryPage';
+import PalmistryResults from './components/PalmistryResults';
 import LandingPage from './components/LandingPage';
 import SpreadSelection from './components/SpreadSelection';
 import QuestionForm from './components/QuestionForm';
@@ -29,10 +31,11 @@ export interface Reading {
 
 function App() {
   const { user, logout } = useAuth();
-  const [currentStep, setCurrentStep] = useState<'landing' | 'spread' | 'question' | 'payment' | 'results' | 'panel' | 'auth'>('landing');
+  const [currentStep, setCurrentStep] = useState<'landing' | 'spread' | 'question' | 'payment' | 'results' | 'palmistry' | 'palmistry-results' | 'panel' | 'auth'>('landing');
   const [selectedSpread, setSelectedSpread] = useState<SpreadType>('single');
   const [question, setQuestion] = useState('');
   const [reading, setReading] = useState<Reading | null>(null);
+  const [palmResult, setPalmResult] = useState<string | null>(null);
 
   useEffect(() => {
     if (user && currentStep === 'auth') {
@@ -209,6 +212,12 @@ Esta lectura completa sugiere una situación compleja pero navegable. Confía en
     setSelectedSpread('single');
     setQuestion('');
     setReading(null);
+    setPalmResult(null);
+  };
+
+  const handlePalmistryComplete = (result: string) => {
+    setPalmResult(result);
+    setCurrentStep('palmistry-results');
   };
 
   return (
@@ -255,7 +264,10 @@ Esta lectura completa sugiere una situación compleja pero navegable. Confía en
       </div>
 
       {currentStep === 'landing' && (
-        <LandingPage onGetStarted={() => setCurrentStep('spread')} />
+        <LandingPage
+          onGetStarted={() => setCurrentStep('spread')}
+          onPalmistry={() => setCurrentStep('palmistry')}
+        />
       )}
 
       {currentStep === 'panel' && (
@@ -290,6 +302,17 @@ Esta lectura completa sugiere una situación compleja pero navegable. Confía en
           onPaymentSuccess={handlePaymentSuccess}
           onBack={() => setCurrentStep('question')}
         />
+      )}
+
+      {currentStep === 'palmistry' && (
+        <PalmistryPage
+          onBack={() => setCurrentStep('landing')}
+          onComplete={handlePalmistryComplete}
+        />
+      )}
+
+      {currentStep === 'palmistry-results' && palmResult && (
+        <PalmistryResults result={palmResult} onRestart={handleStartOver} />
       )}
 
       {currentStep === 'results' && reading && (

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -4,9 +4,10 @@ import TarotCard from './TarotCard';
 
 interface LandingPageProps {
   onGetStarted: () => void;
+  onPalmistry: () => void;
 }
 
-const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
+const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted, onPalmistry }) => {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center px-4 relative">
       <div className="max-w-4xl mx-auto text-center">
@@ -65,7 +66,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
         </div>
 
         {/* CTA Section */}
-        <div className="relative">
+        <div className="relative space-y-4">
           <button
             onClick={onGetStarted}
             className="group bg-gradient-to-r from-purple-600 to-amber-600 hover:from-purple-700 hover:to-amber-700 text-white font-serif text-xl px-12 py-4 rounded-full transition-all duration-300 hover:transform hover:scale-105 hover:shadow-2xl hover:shadow-purple-500/25"
@@ -73,8 +74,16 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
             Comienza tu Viaje
             <ArrowRight className="inline ml-2 group-hover:translate-x-1 transition-transform" size={20} />
           </button>
-          
-          <div className="mt-6 text-purple-300/60">
+
+          <button
+            onClick={onPalmistry}
+            className="group bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-serif text-xl px-12 py-4 rounded-full transition-all duration-300 hover:transform hover:scale-105 hover:shadow-2xl hover:shadow-blue-500/25"
+          >
+            Lectura de Manos 19,99€
+            <ArrowRight className="inline ml-2 group-hover:translate-x-1 transition-transform" size={20} />
+          </button>
+
+          <div className="mt-2 text-purple-300/60">
             <p className="text-sm">Lecturas desde 1,99€ • Entrega instantánea • 100% satisfacción garantizada</p>
           </div>
         </div>

--- a/src/components/PalmistryPage.tsx
+++ b/src/components/PalmistryPage.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { ArrowLeft, Camera, ImageIcon } from 'lucide-react';
+import { generatePalmReading } from '../services/openai';
+
+interface PalmistryPageProps {
+  onBack: () => void;
+  onComplete: (result: string) => void;
+}
+
+const PalmistryPage: React.FC<PalmistryPageProps> = ({ onBack, onComplete }) => {
+  const [image, setImage] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setImage(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const handlePayment = async () => {
+    if (!image) return;
+    setIsProcessing(true);
+    await new Promise(res => setTimeout(res, 2000));
+    try {
+      const result = await generatePalmReading(image);
+      onComplete(result);
+    } catch (err) {
+      console.error(err);
+      alert('Error generando la lectura.');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen py-12 px-4">
+      <div className="max-w-xl mx-auto">
+        <div className="text-center mb-8">
+          <button
+            onClick={onBack}
+            className="inline-flex items-center text-purple-300 hover:text-purple-200 transition-colors mb-6"
+          >
+            <ArrowLeft size={20} className="mr-2" />
+            Volver al Inicio
+          </button>
+          <h1 className="text-4xl font-serif text-transparent bg-gradient-to-r from-purple-400 to-amber-400 bg-clip-text font-bold mb-4">
+            Lectura de Manos
+          </h1>
+          <p className="text-purple-200">Adjunta una foto de la palma de tu mano para recibir tu interpretación.</p>
+        </div>
+
+        <div className="bg-white/5 backdrop-blur-sm rounded-2xl p-6 border border-purple-400/20 mb-6 text-center">
+          {image ? (
+            <img src={image} alt="Palma" className="mx-auto mb-4 max-h-60 rounded-lg" />
+          ) : (
+            <div className="text-purple-300 mb-4">No se ha seleccionado imagen</div>
+          )}
+
+          <label className="flex items-center justify-center space-x-2 bg-white/10 hover:bg-white/20 text-purple-200 py-3 px-6 rounded-lg cursor-pointer mb-4">
+            <ImageIcon size={20} />
+            <span>Adjuntar Imagen</span>
+            <input type="file" accept="image/*" className="hidden" onChange={handleFileChange} />
+          </label>
+
+          <label className="flex items-center justify-center space-x-2 bg-white/10 hover:bg-white/20 text-purple-200 py-3 px-6 rounded-lg cursor-pointer">
+            <Camera size={20} />
+            <span>Tomar Foto</span>
+            <input type="file" accept="image/*" capture="environment" className="hidden" onChange={handleFileChange} />
+          </label>
+        </div>
+
+        <button
+          disabled={!image || isProcessing}
+          onClick={handlePayment}
+          className="w-full bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 disabled:from-gray-600 disabled:to-gray-700 text-white font-serif text-xl py-4 px-8 rounded-lg transition-all duration-300"
+        >
+          {isProcessing ? 'Procesando...' : 'Pagar con PayPal 19,99€'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PalmistryPage;

--- a/src/components/PalmistryResults.tsx
+++ b/src/components/PalmistryResults.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Star, RotateCcw } from 'lucide-react';
+
+interface PalmistryResultsProps {
+  result: string;
+  onRestart: () => void;
+}
+
+const PalmistryResults: React.FC<PalmistryResultsProps> = ({ result, onRestart }) => {
+  return (
+    <div className="min-h-screen py-12 px-4">
+      <div className="max-w-3xl mx-auto">
+        <div className="text-center mb-12">
+          <div className="flex items-center justify-center mb-6">
+            <Star className="text-amber-400 mr-2" size={32} />
+            <h1 className="text-4xl font-serif text-transparent bg-gradient-to-r from-purple-400 to-amber-400 bg-clip-text font-bold">
+              Tu Lectura de Manos
+            </h1>
+            <Star className="text-amber-400 ml-2" size={32} />
+          </div>
+        </div>
+        <div className="bg-white/5 backdrop-blur-sm rounded-2xl p-8 border border-purple-400/20 mb-8">
+          {result.split('\n').map((p, i) => (
+            <p key={i} className="text-purple-200 mb-4 leading-relaxed">
+              {p}
+            </p>
+          ))}
+        </div>
+        <div className="text-center">
+          <button
+            onClick={onRestart}
+            className="inline-flex items-center bg-gradient-to-r from-purple-600 to-amber-600 hover:from-purple-700 hover:to-amber-700 text-white font-serif py-3 px-6 rounded-lg transition-all duration-300"
+          >
+            <RotateCcw className="mr-2" size={18} />
+            Nueva Lectura
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PalmistryResults;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  envPrefix: ['VITE_', 'OPENAI_'],
 });


### PR DESCRIPTION
## Summary
- add palmistry page to capture or upload palm images and simulate PayPal payment
- display palm reading results
- integrate palmistry flow into landing page and app routing
- support palmistry interpretation via OpenAI
- read OpenAI key from `OPENAI_API_KEY` environment variable

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686fdaf96fb083328f3a1596ba655abc